### PR TITLE
docs: use v1.1.1 in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,17 +52,17 @@ First, setup `asdf-plugin-manager` as asdf plugin in asdf:
 ```shell
 asdf plugin add asdf-plugin-manager https://github.com/asdf-community/asdf-plugin-manager.git
 # Pin the asdf-plugin-manager version using git tag or even better using git hash which is immutable.
-asdf plugin update asdf-plugin-manager v1.0.0
+asdf plugin update asdf-plugin-manager v1.1.1
 ```
 
 Then, install the actual `asdf-plugin-manager` CLI:
 
 ```shell
 # Install specific version
-asdf install asdf-plugin-manager 1.0.0
+asdf install asdf-plugin-manager 1.1.1
 
 # Set a version globally (on your ~/.tool-versions file)
-asdf global asdf-plugin-manager 1.0.0
+asdf global asdf-plugin-manager 1.1.1
 
 # Now asdf-plugin-manager command is available
 asdf-plugin-manager version


### PR DESCRIPTION
## What

Use `1.1.1` (not `1.0.0`) in the README guides for installing this.

## Why

- Given the bug in 1.0.0 (fixed in 1.1.0) where it removed all pre-existing plugins (and thus their installed versions of your tools), as per:
   - https://github.com/asdf-community/asdf-plugin-manager/pull/14
- To avoid others experiencing this too. 😅 
