### PR TITLE
fix: ensure asdf-plugin-manager works in expected worktree

### DIFF
--- a/cli/asdf-plugin-manager.sh
+++ b/cli/asdf-plugin-manager.sh
@@ -57,11 +57,17 @@ print_git_compare_url() {
     local plugin_ref_current="$2"
     local plugin_ref_head="$3"
 
-    if $(echo "${provider_url}" | grep -q 'github'); then
-        echo "${plugin_url%.*}/compare/${plugin_ref_current}...${plugin_ref_head}"
-    elif $(echo "${provider_url}" | grep -q 'gitlab'); then
-        echo "${plugin_url%.*}/-/compare/${plugin_ref_current}...${plugin_ref_head}"
-    fi
+    case "${provider_url}" in
+    *github*)
+        echo "${provider_url%.*}/compare/${plugin_ref_current}...${plugin_ref_head}"
+        ;;
+    *gitlab*)
+        echo "${provider_url%.*}/-/compare/${plugin_ref_current}...${plugin_ref_head}"
+        ;;
+    *)
+        echo "Unknown provider: ${provider_url}"
+        ;;
+    esac
 }
 
 export_plugins() {
@@ -72,7 +78,11 @@ export_plugins() {
 checkout_plugin_ref() {
     plugin_name="${1}"
     plugin_ref="${2}"
-    git --git-dir "${PLUGINS_REPOS_DIR}/${plugin_name}/.git" checkout "${plugin_ref}" -q
+    git_dir="${PLUGINS_REPOS_DIR}/${plugin_name}"
+
+    git --git-dir "${git_dir}/.git" \
+        --work-tree "${git_dir}" \
+        checkout "${plugin_ref}"
 }
 
 list_plugins() {


### PR DESCRIPTION
fixes #55

`--git-dir` doesn't work as by itself, so also include `--worktree`